### PR TITLE
Add Rahti/OpenShift deployment support

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+registry=https://registry.npmjs.org/
+always-auth=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@ FROM node:18-alpine AS builder
 # Set working directory
 WORKDIR /app
 
-# Copy package files
+# Copy package files and npmrc
 COPY package*.json ./
 COPY tsconfig.json ./
+COPY .npmrc ./
 
 # Install dependencies
 RUN npm ci --only=production
@@ -27,8 +28,9 @@ RUN adduser -S nodejs -u 1001
 # Set working directory
 WORKDIR /app
 
-# Copy package files
+# Copy package files and npmrc
 COPY package*.json ./
+COPY .npmrc ./
 
 # Install only production dependencies
 RUN npm ci --only=production && npm cache clean --force

--- a/docs/RAHTI_DEPLOYMENT.md
+++ b/docs/RAHTI_DEPLOYMENT.md
@@ -1,0 +1,357 @@
+# 🚀 Rahti (OpenShift) Deployment Guide
+
+This guide explains how to deploy the Picture Store API to Rahti (CSC's OpenShift platform).
+
+## 📋 Prerequisites
+
+- Rahti account and project access
+- `oc` CLI tool installed
+- NPM token for private packages (if needed)
+- Docker image built and pushed to a registry
+
+## 🔑 Setup NPM Token Secret
+
+If your project uses private npm packages, create a secret for the NPM token:
+
+```bash
+# Create NPM token secret
+oc create secret generic npm-token-secret \
+  --from-literal=NPM_TOKEN=your-npm-token-here
+
+# Verify the secret was created
+oc get secrets | grep npm-token
+```
+
+## 🏗️ Build Configuration
+
+Create a BuildConfig that uses the NPM token:
+
+```yaml
+# buildconfig.yaml
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: picture-store-api
+spec:
+  source:
+    type: Git
+    git:
+      uri: https://github.com/your-username/your-repo.git
+      ref: main
+  strategy:
+    type: Docker
+    dockerStrategy:
+      env:
+        - name: NPM_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: npm-token-secret
+              key: NPM_TOKEN
+  output:
+    to:
+      kind: ImageStreamTag
+      name: picture-store-api:latest
+```
+
+Apply the BuildConfig:
+```bash
+oc apply -f buildconfig.yaml
+```
+
+## 🚀 Deployment Configuration
+
+Create a DeploymentConfig:
+
+```yaml
+# deploymentconfig.yaml
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: picture-store-api
+spec:
+  replicas: 1
+  selector:
+    app: picture-store-api
+  template:
+    metadata:
+      labels:
+        app: picture-store-api
+    spec:
+      containers:
+      - name: picture-store-api
+        image: picture-store-api:latest
+        ports:
+        - containerPort: 3001
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: PORT
+          value: "3001"
+        - name: JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: app-secrets
+              key: JWT_SECRET
+        - name: MONGODB_URI
+          valueFrom:
+            secretKeyRef:
+              name: app-secrets
+              key: MONGODB_URI
+        volumeMounts:
+        - name: uploads-volume
+          mountPath: /app/uploads
+        - name: data-volume
+          mountPath: /app/data
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 3001
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3001
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: uploads-volume
+        persistentVolumeClaim:
+          claimName: uploads-pvc
+      - name: data-volume
+        persistentVolumeClaim:
+          claimName: data-pvc
+  triggers:
+  - type: ImageChange
+    imageChangeParams:
+      automatic: true
+      containerNames:
+      - picture-store-api
+      from:
+        kind: ImageStreamTag
+        name: picture-store-api:latest
+```
+
+## 💾 Persistent Volume Claims
+
+Create PVCs for data persistence:
+
+```yaml
+# pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: uploads-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+```
+
+## 🔒 Application Secrets
+
+Create secrets for sensitive environment variables:
+
+```bash
+# Create application secrets
+oc create secret generic app-secrets \
+  --from-literal=JWT_SECRET=your-secure-jwt-secret-64-characters-long \
+  --from-literal=MONGODB_URI=mongodb://your-mongodb-connection-string
+
+# Verify secrets
+oc get secrets | grep app-secrets
+```
+
+## 🌐 Service and Route
+
+Create a Service and Route to expose the application:
+
+```yaml
+# service-route.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: picture-store-api-service
+spec:
+  selector:
+    app: picture-store-api
+  ports:
+  - port: 3001
+    targetPort: 3001
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: picture-store-api-route
+spec:
+  to:
+    kind: Service
+    name: picture-store-api-service
+  port:
+    targetPort: 3001
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+```
+
+## 📝 Complete Deployment Steps
+
+1. **Login to Rahti:**
+```bash
+oc login https://rahti.csc.fi:8443
+oc project your-project-name
+```
+
+2. **Create secrets:**
+```bash
+# NPM token (if needed)
+oc create secret generic npm-token-secret \
+  --from-literal=NPM_TOKEN=your-npm-token
+
+# Application secrets
+oc create secret generic app-secrets \
+  --from-literal=JWT_SECRET=your-jwt-secret \
+  --from-literal=MONGODB_URI=your-mongodb-uri
+```
+
+3. **Create persistent volumes:**
+```bash
+oc apply -f pvc.yaml
+```
+
+4. **Create and start build:**
+```bash
+oc apply -f buildconfig.yaml
+oc start-build picture-store-api
+```
+
+5. **Deploy application:**
+```bash
+oc apply -f deploymentconfig.yaml
+```
+
+6. **Expose service:**
+```bash
+oc apply -f service-route.yaml
+```
+
+7. **Check deployment:**
+```bash
+# Check pods
+oc get pods
+
+# Check route
+oc get routes
+
+# Check logs
+oc logs -f deployment/picture-store-api
+```
+
+## 🔍 Monitoring and Troubleshooting
+
+### Check Application Status
+```bash
+# View all resources
+oc get all
+
+# Check pod logs
+oc logs -f pod/picture-store-api-xxx
+
+# Check events
+oc get events --sort-by='.lastTimestamp'
+```
+
+### Health Check
+```bash
+# Get route URL
+ROUTE_URL=$(oc get route picture-store-api-route -o jsonpath='{.spec.host}')
+
+# Test health endpoint
+curl https://$ROUTE_URL/health
+```
+
+### Scale Application
+```bash
+# Scale up
+oc scale dc/picture-store-api --replicas=3
+
+# Scale down
+oc scale dc/picture-store-api --replicas=1
+```
+
+## 🔄 Updates and Rollbacks
+
+### Update Application
+```bash
+# Trigger new build
+oc start-build picture-store-api
+
+# Or rollout latest
+oc rollout latest dc/picture-store-api
+```
+
+### Rollback
+```bash
+# View rollout history
+oc rollout history dc/picture-store-api
+
+# Rollback to previous version
+oc rollout undo dc/picture-store-api
+```
+
+## 📊 Resource Limits
+
+Add resource limits to the DeploymentConfig:
+
+```yaml
+resources:
+  limits:
+    memory: "512Mi"
+    cpu: "500m"
+  requests:
+    memory: "256Mi"
+    cpu: "250m"
+```
+
+## 🔒 Security Best Practices
+
+1. **Use secrets for sensitive data**
+2. **Enable HTTPS with TLS termination**
+3. **Set resource limits**
+4. **Use health checks**
+5. **Run as non-root user** (already configured in Dockerfile)
+6. **Keep images updated**
+
+## 🆘 Common Issues
+
+### Build Fails
+- Check NPM token is correct
+- Verify .npmrc file is included
+- Check build logs: `oc logs -f bc/picture-store-api`
+
+### Pod Won't Start
+- Check secrets exist and are correctly named
+- Verify environment variables
+- Check resource limits
+
+### Health Check Fails
+- Ensure `/health` endpoint is implemented
+- Check port configuration (3001)
+- Verify application is actually starting
+
+---
+
+For more help, check the [Rahti documentation](https://docs.csc.fi/cloud/rahti/) or contact CSC support.

--- a/openshift/buildconfig.yaml
+++ b/openshift/buildconfig.yaml
@@ -1,0 +1,33 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: picture-store-api
+  labels:
+    app: picture-store-api
+spec:
+  source:
+    type: Git
+    git:
+      uri: https://github.com/your-username/your-repo.git
+      ref: main
+  strategy:
+    type: Docker
+    dockerStrategy:
+      env:
+        - name: NPM_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: npm-token-secret
+              key: NPM_TOKEN
+  output:
+    to:
+      kind: ImageStreamTag
+      name: picture-store-api:latest
+  triggers:
+    - type: GitHub
+      github:
+        secret: github-webhook-secret
+    - type: Generic
+      generic:
+        secret: generic-webhook-secret
+    - type: ConfigChange

--- a/openshift/deploy.sh
+++ b/openshift/deploy.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+# Rahti Deployment Script for Picture Store API
+# Usage: ./deploy.sh [npm-token] [jwt-secret] [mongodb-uri]
+
+set -e
+
+echo "🚀 Deploying Picture Store API to Rahti..."
+
+# Check if oc is installed
+if ! command -v oc &> /dev/null; then
+    echo "❌ Error: oc CLI tool is not installed"
+    echo "Please install it from: https://docs.openshift.com/container-platform/4.9/cli_reference/openshift_cli/getting-started-cli.html"
+    exit 1
+fi
+
+# Check if logged in to OpenShift
+if ! oc whoami &> /dev/null; then
+    echo "❌ Error: Not logged in to OpenShift"
+    echo "Please login first: oc login https://rahti.csc.fi:8443"
+    exit 1
+fi
+
+# Get current project
+PROJECT=$(oc project -q)
+echo "📁 Current project: $PROJECT"
+
+# Get parameters
+NPM_TOKEN=${1:-""}
+JWT_SECRET=${2:-""}
+MONGODB_URI=${3:-""}
+
+# Prompt for missing parameters
+if [ -z "$NPM_TOKEN" ]; then
+    read -p "🔑 Enter NPM token (or press Enter to skip): " NPM_TOKEN
+fi
+
+if [ -z "$JWT_SECRET" ]; then
+    read -p "🔐 Enter JWT secret (64 characters recommended): " JWT_SECRET
+fi
+
+if [ -z "$MONGODB_URI" ]; then
+    read -p "🗄️ Enter MongoDB URI (or press Enter for local file storage): " MONGODB_URI
+fi
+
+# Set default MongoDB URI if empty
+if [ -z "$MONGODB_URI" ]; then
+    MONGODB_URI="file://local"
+fi
+
+echo ""
+echo "📋 Deployment Summary:"
+echo "   Project: $PROJECT"
+echo "   NPM Token: ${NPM_TOKEN:+***configured***}"
+echo "   JWT Secret: ${JWT_SECRET:+***configured***}"
+echo "   MongoDB URI: ${MONGODB_URI}"
+echo ""
+
+read -p "Continue with deployment? (y/N): " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "❌ Deployment cancelled"
+    exit 1
+fi
+
+echo "🔧 Creating secrets..."
+
+# Create NPM token secret if provided
+if [ ! -z "$NPM_TOKEN" ]; then
+    oc create secret generic npm-token-secret \
+        --from-literal=NPM_TOKEN="$NPM_TOKEN" \
+        --dry-run=client -o yaml | oc apply -f -
+    echo "✅ NPM token secret created/updated"
+fi
+
+# Create application secrets
+oc create secret generic app-secrets \
+    --from-literal=JWT_SECRET="$JWT_SECRET" \
+    --from-literal=MONGODB_URI="$MONGODB_URI" \
+    --dry-run=client -o yaml | oc apply -f -
+echo "✅ Application secrets created/updated"
+
+echo "💾 Creating persistent volumes..."
+oc apply -f pvc.yaml
+echo "✅ Persistent volumes created"
+
+echo "🏗️ Creating build configuration..."
+oc apply -f buildconfig.yaml
+echo "✅ Build configuration created"
+
+echo "🚀 Creating deployment configuration..."
+oc apply -f deploymentconfig.yaml
+echo "✅ Deployment configuration created"
+
+echo "🌐 Creating service and route..."
+oc apply -f service-route.yaml
+echo "✅ Service and route created"
+
+echo "🔨 Starting build..."
+oc start-build picture-store-api --follow
+
+echo "⏳ Waiting for deployment..."
+oc rollout status dc/picture-store-api --timeout=300s
+
+echo "🔍 Getting route URL..."
+ROUTE_URL=$(oc get route picture-store-api-route -o jsonpath='{.spec.host}')
+
+echo ""
+echo "🎉 Deployment completed successfully!"
+echo ""
+echo "📊 Deployment Status:"
+oc get pods -l app=picture-store-api
+echo ""
+echo "🌍 Application URL: https://$ROUTE_URL"
+echo "🏥 Health Check: https://$ROUTE_URL/health"
+echo ""
+echo "📝 Useful commands:"
+echo "   View logs: oc logs -f dc/picture-store-api"
+echo "   Scale app: oc scale dc/picture-store-api --replicas=2"
+echo "   Get status: oc get all -l app=picture-store-api"
+echo ""
+
+# Test health endpoint
+echo "🏥 Testing health endpoint..."
+if curl -s -f "https://$ROUTE_URL/health" > /dev/null; then
+    echo "✅ Health check passed!"
+else
+    echo "⚠️ Health check failed - application may still be starting"
+fi
+
+echo "✨ Deployment script completed!"

--- a/openshift/deploymentconfig.yaml
+++ b/openshift/deploymentconfig.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: picture-store-api
+  labels:
+    app: picture-store-api
+spec:
+  replicas: 1
+  selector:
+    app: picture-store-api
+  template:
+    metadata:
+      labels:
+        app: picture-store-api
+    spec:
+      containers:
+      - name: picture-store-api
+        image: picture-store-api:latest
+        ports:
+        - containerPort: 3001
+          protocol: TCP
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: PORT
+          value: "3001"
+        - name: JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: app-secrets
+              key: JWT_SECRET
+        - name: MONGODB_URI
+          valueFrom:
+            secretKeyRef:
+              name: app-secrets
+              key: MONGODB_URI
+        volumeMounts:
+        - name: uploads-volume
+          mountPath: /app/uploads
+        - name: data-volume
+          mountPath: /app/data
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 3001
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3001
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        resources:
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+      volumes:
+      - name: uploads-volume
+        persistentVolumeClaim:
+          claimName: uploads-pvc
+      - name: data-volume
+        persistentVolumeClaim:
+          claimName: data-pvc
+  triggers:
+  - type: ImageChange
+    imageChangeParams:
+      automatic: true
+      containerNames:
+      - picture-store-api
+      from:
+        kind: ImageStreamTag
+        name: picture-store-api:latest
+  - type: ConfigChange

--- a/openshift/pvc.yaml
+++ b/openshift/pvc.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: uploads-pvc
+  labels:
+    app: picture-store-api
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: standard
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-pvc
+  labels:
+    app: picture-store-api
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: standard

--- a/openshift/service-route.yaml
+++ b/openshift/service-route.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: picture-store-api-service
+  labels:
+    app: picture-store-api
+spec:
+  selector:
+    app: picture-store-api
+  ports:
+  - name: http
+    port: 3001
+    targetPort: 3001
+    protocol: TCP
+  type: ClusterIP
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: picture-store-api-route
+  labels:
+    app: picture-store-api
+spec:
+  to:
+    kind: Service
+    name: picture-store-api-service
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None


### PR DESCRIPTION
- Added .npmrc file for NPM token authentication
- Updated Dockerfile to use .npmrc for private packages
- Created comprehensive Rahti deployment guide
- Added OpenShift YAML configurations:
  - BuildConfig with NPM token support
  - DeploymentConfig with health checks and resource limits
  - PersistentVolumeClaims for data persistence
  - Service and Route for external access
- Added automated deployment script (deploy.sh)
- Ready for Rahti (CSC OpenShift) deployment